### PR TITLE
Disable dev tools auto-open

### DIFF
--- a/src/main/index.dev.js
+++ b/src/main/index.dev.js
@@ -10,8 +10,8 @@
 // Set environment for development
 process.env.NODE_ENV = 'development'
 
-// Install `electron-debug` with `devtron`
-require('electron-debug')({ showDevTools: true })
+// Install `electron-debug` without automatically opening dev tools
+require('electron-debug')({ showDevTools: false })
 
 // Install `vue-devtools`
 require('electron').app.on('ready', () => {

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -30,7 +30,9 @@ function createWindow () {
     width: 1080,
     frame: false,
     webPreferences: {
-      webSecurity: false
+      webSecurity: false,
+      // Disable dev tools in production builds
+      devTools: process.env.NODE_ENV === 'development'
     }
   })
 


### PR DESCRIPTION
## Summary
- stop electron-debug from opening dev tools
- disable dev tools for production builds via BrowserWindow options

## Testing
- `npm test` *(fails: `karma` not found)*
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6866f2c6dbb8833186df50f5544c8d89