### PR TITLE
Fix README sample quiz instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ You can download and install this app from [Releases page](https://github.com/ku
 Testownik provided keyboard support while test is running. You can use <kbd>1</kbd> - <kbd>9</kbd> keys to select/unselect answer choices and <kbd>Space</kbd> key to accept answer.
 
 ### Sample Quiz
-If You want to see sample quiz, please press <kbd>T</kbd> key after launch.
+If You want to see sample quiz, press the **EXAMPLE** button after launch.
 
 
 ## Building for Windows


### PR DESCRIPTION
## Summary
- document pressing the EXAMPLE button for the Sample Quiz section
- ensure README ends with a newline

## Testing
- `npm test` *(fails: karma not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868058e24c88331a5ad0438f870c846