### PR TITLE
Improve landing page unit test

### DIFF
--- a/test/unit/specs/LandingPage.spec.js
+++ b/test/unit/specs/LandingPage.spec.js
@@ -2,12 +2,16 @@ import Vue from 'vue'
 import LandingPage from '@/components/LandingPage'
 
 describe('LandingPage.vue', () => {
-  it('should render correct contents', () => {
+  it('should render important UI elements', () => {
     const vm = new Vue({
       el: document.createElement('div'),
       render: h => h(LandingPage)
     }).$mount()
 
-    expect(vm.$el.querySelector('.title').textContent).to.contain('Welcome to your new project!')
+    const dragArea = vm.$el.querySelector('#drag')
+    expect(dragArea).to.not.equal(null)
+    const exampleButton = Array.from(vm.$el.querySelectorAll('button'))
+      .find(btn => btn.textContent.trim() === 'EXAMPLE')
+    expect(exampleButton).to.not.equal(undefined)
   })
 })


### PR DESCRIPTION
## Summary
- update LandingPage unit test to check drag area and EXAMPLE button

## Testing
- `npm run lint`
- `npm run unit` *(fails: libgtk-x11-2.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_6868060267f4833199dbfed91caca90d